### PR TITLE
Add rename workflow

### DIFF
--- a/.github/workflows/rename.yml
+++ b/.github/workflows/rename.yml
@@ -1,0 +1,42 @@
+# Please set 'QIITA_TOKEN' secret to your repository
+name: Rename articles
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 12 * * *'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  rename_articles:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-beam@v1
+        with:
+          otp-version: "27.3.4.1"
+          elixir-version: "1.18.4"
+      - name: Rename articles
+        run: elixir bin/normalize-filenames.exs
+        env:
+          QIITA_TOKEN: ${{ secrets.QIITA_TOKEN }}
+        shell: bash
+      - name: Commit and push diff # Not executed recursively even if `push` is triggered. See https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
+        run: |
+          git add public/*
+          if ! git diff --staged --exit-code --quiet; then
+            git config --global user.name 'TORIFUKUKaiou'
+            git config --global user.email 'torifuku.kaiou@gmail.com'
+            git commit -m '闘魂注入という名のリネーム'
+            git push
+          fi
+        shell: bash


### PR DESCRIPTION
## Summary
- add GitHub Action workflow to rename article files
- rename step for clarity and tweak commit message

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6868979d02dc83209029e0084f6c52d5