### PR TITLE
Update pull workflow for Node 22

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -18,12 +18,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: "18.16.0"
+          node-version: "22"
       - name: Install qiita-cli
         run: npm install -g @qiita/qiita-cli@latest
         shell: bash


### PR DESCRIPTION
## Summary
- update `actions/checkout` to `v4`
- update `actions/setup-node` to `v4`
- use Node.js `22` in the pull workflow

## Testing
- `npm test` *(fails: Missing script and no network access)*

------
https://chatgpt.com/codex/tasks/task_e_68689955cfa883208d6b09855857d430