### PR TITLE
Fix workflow to use erlef beam setup

### DIFF
--- a/.github/workflows/rename.yml
+++ b/.github/workflows/rename.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-beam@v1
+      - uses: erlef/setup-beam@v1
         with:
           otp-version: "27.3.4.1"
           elixir-version: "1.18.4"


### PR DESCRIPTION
## Summary
- use `erlef/setup-beam@v1` in rename workflow

## Testing
- `npm test` *(fails: Missing script: "test"*)

------
https://chatgpt.com/codex/tasks/task_e_68689b4bd2e48320ae85463649879aec