### PR TITLE
Fix rename workflow add command

### DIFF
--- a/.github/workflows/rename.yml
+++ b/.github/workflows/rename.yml
@@ -32,7 +32,7 @@ jobs:
         shell: bash
       - name: Commit and push diff # Not executed recursively even if `push` is triggered. See https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
         run: |
-          git add public/*
+          git add -A public
           if ! git diff --staged --exit-code --quiet; then
             git config --global user.name 'TORIFUKUKaiou'
             git config --global user.email 'torifuku.kaiou@gmail.com'


### PR DESCRIPTION
## Summary
- use `git add -A public` in rename workflow so all changes are staged

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6868a07765948320b1c6dd1ee9e81145